### PR TITLE
Increase and decrease brightness keys reversed

### DIFF
--- a/Keyboards/Kira.md
+++ b/Keyboards/Kira.md
@@ -81,8 +81,8 @@ The Animation layer is accessible with by holding <kbd>Right Alt</kbd> + <kbd>Ri
 | <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>F1</kbd> | Change key colors |
 | <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>F2</kbd> | Change underglow color |
 | <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>F7</kbd> | Change animation |
-| <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>-</kbd> | Increase Brightness |
-| <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>+</kbd> | Decrease Brightness |
+| <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>+</kbd> | Increase Brightness |
+| <kbd>Right Alt</kbd> + <kbd>Right Control</kbd> + <kbd>-</kbd> | Decrease Brightness |
 
 #### Fading
 


### PR DESCRIPTION
Typo in the guide where + and - were flipped for increase and decrease brightness.

EDIT - Just noticed that it's also wrong on the associated image